### PR TITLE
Use Ingestor AMI to create EC2 instance

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -25,6 +25,8 @@ module "network" {
 }
 
 module "instance" {
+  // Custom AMI that has server code and nodejs installed
+  ami               = "ami-05bc9eff26b996ebd"
   source            = "./instance"
   network_interface = module.network.network_interface
 }
@@ -45,7 +47,7 @@ module "lambda" {
   }
 
   vpc_config = {
-    subnet_ids = [ module.network.subnet_id ]
-    security_group_ids = [ module.network.security_group_id ]
+    subnet_ids         = [module.network.subnet_id]
+    security_group_ids = [module.network.security_group_id]
   }
 }


### PR DESCRIPTION
An EC2 instance was created and it was configured with all the necessary packages and server code.From that instance an AMI was created, which is used in creating the Ingestor EC2 instance.

The EC2 instance will have NodeJS installed, and server code including the installed node_modules on it.

The fact that we have an AMI, renders the deploy server code to S3 step in the pipeline useless.We will keep there for the near future.